### PR TITLE
Update linux-engicam_5.4.70.bb

### DIFF
--- a/recipes-kernel/linux/linux-engicam_5.4.70.bb
+++ b/recipes-kernel/linux/linux-engicam_5.4.70.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 DEPENDS += "lzop-native bc-native"
 
+LINUX_VERSION ?= "5.4.70"
 KERNEL_BRANCH ?= "5.4.70"
 KERNEL_SRC ?= "git://github.com/engicam-stable/linux-engicam-nxp.git;protocol=http"
 SRC_URI = "${KERNEL_SRC};branch=${KERNEL_BRANCH}"


### PR DESCRIPTION
Add LINUX_VERSION ?= "5.4.70" in order to get rid of errors when trying to use devtool to modify the kernel sources